### PR TITLE
Fixed issue with warning callout, wrong return val

### DIFF
--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -103,7 +103,7 @@
       pattern: /^\s*<div class="callout__warn"><span class="callout__icon"><strong class="visually-hidden">Warning: <\/strong><\/span><span class="callout__text">(.*?)<\/span><\/div>$/,
       fromBlock: function(match) {
         return {
-          tipCallout: match[1]
+          warnCallout: match[1]
         };
       },
       toBlock: function(data) {


### PR DESCRIPTION
Return value was for tip callout, which caused an issue when trying to use the component in the CMS. Bad copy and pasting on my behalf.